### PR TITLE
fix Cp1252 issue on Windows builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,3 +19,8 @@ dependencies {
 
 task stage(dependsOn: ['build', 'clean'])
 build.mustRunAfter clean
+
+// fix Cp1252 issue on Windows builds
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+javadoc.options.encoding = 'UTF-8'


### PR DESCRIPTION
use UTF-8 for international chars